### PR TITLE
chore(gradle):DEV-174002 Upgrade to latest Gradle (version 8.6, depen…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.apptentive.apptentive_flutter'
 version '1.0'
 
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.4.1'
     }
 }
 
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 android {
     compileSdkVersion 33
 
+    namespace 'com.apptentive.apptentive_flutter'
+    
     defaultConfig {
         minSdkVersion 28
         targetSdkVersion 33

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/test/apptentive_flutter_test.dart
+++ b/test/apptentive_flutter_test.dart
@@ -7,13 +7,15 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       return '42';
     });
   });
 
   tearDown(() {
-    channel.setMockMethodCallHandler(null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('getPlatformVersion', () async {


### PR DESCRIPTION
…dency version 8.4.1)

## Acceptance criteria

- [x] Gradle is updated to 8.0.2 or the latest we can go to on our current version of Flutter
- [x] Android app still builds locally and in CCI
- [x] Imperative apply is removed to apply Flutter Gradle plugins (see: [here](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply))

## Notes

Updated Gradle version to the latest 8.6 and its dependency version to 8.4.1
Updated Kotlin version to the latest 2.0.0